### PR TITLE
DND-12 Added win screen

### DIFF
--- a/src/ui/components/win-screen.js
+++ b/src/ui/components/win-screen.js
@@ -1,0 +1,10 @@
+import {html} from '../lib.js'
+
+const WinScreen = (props) => html`
+	<article>
+		<h1>Well done. You won.</h1>
+		<p><button autofocus onClick=${props.onNewGame}>Play again</a></p>
+	</article>
+`
+
+export default WinScreen


### PR DESCRIPTION
Win screen is seen when users win a game. They are given the option of playing again or quitting. This allows it to now be no longer commented in dungeons-and-decks.js